### PR TITLE
Add method argument for longevity

### DIFF
--- a/R/longevity.R
+++ b/R/longevity.R
@@ -10,7 +10,7 @@
 #'   stasis, shrinkage).
 #' @param startLife Index of the first stage at which the author considers the
 #'   beginning of life.
-#' @param initPop Initial population size.
+#' @param initPop Initial population size used to calculate maximum longevity.
 #' @param run Number of iterations that maximum longevity will be calculated
 #'   over.
 #' @param method Should function return life expectancy (\code{"life"}), maximum
@@ -46,11 +46,15 @@
 #'   Sunderland, Massachusetts, USA
 #' @keywords ~kwd1 ~kwd2
 #' @examples
-#' matU <- matrix(c(0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.3, 0, 0, 0, 0, 0.1, 0.1),
-#'                nrow = 4, byrow = TRUE)
-#' 
-#' longevity(matU, startLife = 1, initPop = 100, run = 1000)
-#' 
+#' matU <- rbind(c(0.0, 0.0, 0.0, 0.0),
+#'               c(0.5, 0.0, 0.0, 0.0),
+#'               c(0.0, 0.3, 0.0, 0.0),
+#'               c(0.0, 0.0, 0.1, 0.1))
+#'
+#' longevity(matU)
+#' longevity(matU, startLife = 2, method = 'life')
+#' longevity(matU, startLife = 2, run = 100, method = 'longevity')
+#'
 #' @export longevity
 longevity <- function(matU, startLife = 1, initPop = 100, run = 1000,
                       method = 'both') {

--- a/R/longevity.R
+++ b/R/longevity.R
@@ -4,27 +4,36 @@
 #' in a matrix population model
 #'
 #' This function applies Markov chain approaches to obtain the mean and variance
-#' in life expectancy, and a loop to calculate maximum longevity.
+#' in life expectancy, and/or a loop to calculate maximum longevity.
 #'
 #' @param matU A matrix containing only survival-dependent processes (growth,
 #'   stasis, shrinkage).
-#' @param startLife The first stage at which the author consider the beginning
-#'   of life.
+#' @param startLife Index of the first stage at which the author considers the
+#'   beginning of life.
 #' @param initPop Initial population size.
 #' @param run Number of iterations that maximum longevity will be calculated
 #'   over.
+#' @param method Should function return life expectancy (\code{"life"}), maximum
+#'   longevity (\code{"longevity"}), or both (\code{"both"})?
 #' @return Returns a list including the following named elements (each of which
 #'   contain a single numeric value):
+#'   
+#'   If \code{method == "life"}:
 #'
 #'   - \code{eta}: mean life expectancy conditional on entering the life cycle
 #'   at life stage described by \code{startLife}
 #'
 #'   - \code{var_eta}: variance in life expectancy conditional on entering the
 #'   life cycle at life stage described by \code{startLife}
+#'   
+#'   If \code{method == "longevity"}:
 #'
 #'   - \code{Max}: maximum longevity observed by iterating a population vector
 #'   with \code{initPop} individuals in stage \code{startLife} up to \code{run}
 #'   times
+#'   
+#'   If \code{method == "both"}, returns a list containing all three elements
+#'   described above.
 #' @note %% ~~further notes~~
 #' @author Roberto Salguero-Gomez <rob.salguero@@zoo.ox.ac.uk>
 #' @author Hal Caswell <hcaswell@@whoi.edu>
@@ -43,7 +52,8 @@
 #' longevity(matU, startLife = 1, initPop = 100, run = 1000)
 #' 
 #' @export longevity
-longevity <- function(matU, startLife = 1, initPop = 100, run = 1000) {
+longevity <- function(matU, startLife = 1, initPop = 100, run = 1000,
+                      method = 'both') {
   #Function to calculate mean life expectancy and maximum longevity from
   # H. Caswell's matlab code, and Morris & Doak:
 
@@ -51,6 +61,8 @@ longevity <- function(matU, startLife = 1, initPop = 100, run = 1000) {
     stop('matU missing')
   } else if (any(is.na(matU))) {
     stop('matU contains missing values')
+  } else if (!method %in% c('life', 'longevity', 'both')) {
+    stop("method must be one of 'life', 'longevity', or 'both'")
   } else if (all(matU == 0)) {
     warning('all elements of matU are zero')
     return(list(eta = 0, var_eta = 0, Max = 0))
@@ -60,22 +72,26 @@ longevity <- function(matU, startLife = 1, initPop = 100, run = 1000) {
   
   matDim <- dim(matU)[1]
   
-  #Mean and variance of life expectancy
-  N <- solve(diag(matDim) - matU)
-  out$eta <- colSums(N)[startLife]
-  out$var_eta <- (colSums(2 * N %*% N - N) - (colSums(N) * colSums(N)))[startLife]
-  
-  #Maximum longevity up to 'run' iterations
-  popVector <- c(rep(0, matDim))
-  popVector[startLife] <- initPop
-  lifespanLeftover <- matrix(0, run, 1)
-  for (n in 1:run)	{
-    lifespanLeftover[n] <- sum(popVector)
-    popVector <- matU %*% popVector
+  if(method %in% c('life', 'both')) {
+    #Mean and variance of life expectancy
+    N <- solve(diag(matDim) - matU)
+    out$eta <- colSums(N)[startLife]
+    out$var_eta <- (colSums(2 * N %*% N - N) - (colSums(N) * colSums(N)))[startLife]
   }
   
-  out$Max <- max(which(lifespanLeftover > 1))
-  if (out$Max == Inf) {out$Max <- run} # don't think this condition will ever be met
+  if(method %in% c('longevity', 'both')) {
+    #Maximum longevity up to 'run' iterations
+    popVector <- c(rep(0, matDim))
+    popVector[startLife] <- initPop
+    lifespanLeftover <- matrix(0, run, 1)
+    for (n in 1:run)	{
+      lifespanLeftover[n] <- sum(popVector)
+      popVector <- matU %*% popVector
+    }
+    
+    out$Max <- max(which(lifespanLeftover > 1))
+    if (out$Max == Inf) {out$Max <- run} # don't think this condition will ever be met
+  }
   
 	return(out)
 }

--- a/R/longevity.R
+++ b/R/longevity.R
@@ -55,7 +55,7 @@ longevity <- function(matU, startLife = 1, initPop = 100, run = 1000) {
     return(list(eta = 0, var_eta = 0, Max = 0))
   }
   
-  out = NULL
+  out <- NULL
   
   matDim <- dim(matU)[1]
   
@@ -64,17 +64,17 @@ longevity <- function(matU, startLife = 1, initPop = 100, run = 1000) {
   out$eta <- colSums(N)[startLife]
   out$var_eta <- (colSums(2 * N %*% N - N) - (colSums(N) * colSums(N)))[startLife]
   
-  #Maximum longevity up to 'run' interations.
-  popVector <- c(rep(0,matDim))
+  #Maximum longevity up to 'run' iterations
+  popVector <- c(rep(0, matDim))
   popVector[startLife] <- initPop
-  lifespanLeftover=matrix(0,run,1)
+  lifespanLeftover <- matrix(0, run, 1)
   for (n in 1:run)	{
-    lifespanLeftover[n]=sum(popVector)
-    popVector=matU%*%popVector
+    lifespanLeftover[n] <- sum(popVector)
+    popVector <- matU %*% popVector
   }
   
-  out$Max <- max(which(lifespanLeftover>1))
-  if (out$Max==Inf) {out$Max=run}
+  out$Max <- max(which(lifespanLeftover > 1))
+  if (out$Max == Inf) {out$Max <- run} # don't think this condition will ever be met
   
 	return(out)
 }

--- a/R/longevity.R
+++ b/R/longevity.R
@@ -90,7 +90,7 @@ longevity <- function(matU, startLife = 1, initPop = 100, run = 1000,
     }
     
     out$Max <- max(which(lifespanLeftover > 1))
-    if (out$Max == Inf) {out$Max <- run} # don't think this condition will ever be met
+    if (out$Max == Inf) {out$Max <- run} # don't think this condition can ever be met
   }
   
 	return(out)

--- a/R/longevity.R
+++ b/R/longevity.R
@@ -1,43 +1,44 @@
-#' A function to calculate measures of longevity.
-#' 
+#' Calculate measures of life expectancy and longevity
+#'
 #' A function to calculate life expectancy and maximum longevity of individuals
 #' in a matrix population model
-#' 
+#'
 #' This function applies Markov chain approaches to obtain the mean and variance
 #' in life expectancy, and a loop to calculate maximum longevity.
-#' 
+#'
 #' @param matU A matrix containing only survival-dependent processes (growth,
-#' stasis, shrinkage).
+#'   stasis, shrinkage).
 #' @param startLife The first stage at which the author consider the beginning
-#' of life.
+#'   of life.
 #' @param initPop Initial population size.
-#' @param run Number of iterations that the maximum longevity will be
-#' calculated for.
-#' @return This function applies Markov chain approaches to obtain mean life
-#' expectancy, and a loop to calculate maximum longevity. Outputs are:
-#' 
-#' - 'eta': mean life expectancy conditional on entering the life cycle on life
-#' stage described by 'startLife'.
-#' 
-#' - 'var_eta': variance in life expectancy conditional on entering the life
-#' cycle on life stage described by 'startLife'.
-#' 
-#' - 'Max': maximum longevity observed by iterating a population vector with
-#' 'initPop' individuals in stage 'startLife' up to 'run' times.
+#' @param run Number of iterations that maximum longevity will be calculated
+#'   over.
+#' @return Returns a list including the following named elements (each of which
+#'   contain a single numeric value):
+#'
+#'   - \code{eta}: mean life expectancy conditional on entering the life cycle
+#'   at life stage described by \code{startLife}
+#'
+#'   - \code{var_eta}: variance in life expectancy conditional on entering the
+#'   life cycle at life stage described by \code{startLife}
+#'
+#'   - \code{Max}: maximum longevity observed by iterating a population vector
+#'   with \code{initPop} individuals in stage \code{startLife} up to \code{run}
+#'   times
 #' @note %% ~~further notes~~
 #' @author Roberto Salguero-Gomez <rob.salguero@@zoo.ox.ac.uk>
 #' @author Hal Caswell <hcaswell@@whoi.edu>
 #' @references Caswell, H. (2001) Matrix Population Models: Construction,
-#' Analysis, and Interpretation. Sinauer Associates; 2nd edition. ISBN:
-#' 978-0878930968
-#' 
-#' Morris, W. F., and D. F. Doak. 2003. Quantitative Conservation 
-#' Biology: Theory and Practice of Population Viability Analysis. 
-#' Sinauer Associates, Sunderland, Massachusetts, USA
+#'   Analysis, and Interpretation. Sinauer Associates; 2nd edition. ISBN:
+#'   978-0878930968
+#'
+#'   Morris, W. F., and D. F. Doak. 2003. Quantitative Conservation Biology:
+#'   Theory and Practice of Population Viability Analysis. Sinauer Associates,
+#'   Sunderland, Massachusetts, USA
 #' @keywords ~kwd1 ~kwd2
 #' @examples
-#' 
-#' matU <- matrix (c(0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.3, 0, 0, 0, 0, 0.1, 0.1), nrow = 4, byrow = TRUE)
+#' matU <- matrix(c(0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.3, 0, 0, 0, 0, 0.1, 0.1),
+#'                nrow = 4, byrow = TRUE)
 #' 
 #' longevity(matU, startLife = 1, initPop = 100, run = 1000)
 #' 

--- a/R/longevity.R
+++ b/R/longevity.R
@@ -68,7 +68,7 @@ longevity <- function(matU, startLife = 1, initPop = 100, run = 1000) {
   popVector <- c(rep(0,matDim))
   popVector[startLife] <- initPop
   lifespanLeftover=matrix(0,run,1)
-  for (n in 1:1000)	{
+  for (n in 1:run)	{
     lifespanLeftover[n]=sum(popVector)
     popVector=matU%*%popVector
   }

--- a/R/matrixElementPerturbation.R
+++ b/R/matrixElementPerturbation.R
@@ -1,13 +1,21 @@
-#' A function to perform element perturbation of a matrix population model for any demographic statistic.
-#' 
-#' A function to perform element perturbation of a matrix population model and measure the response of the per-capita population growth rate at equilibrium or (with a user-supplied function) any other demographic statistic.
-#' 
-#' @param matU The U matrix (processes related to survival, growth and retrogression).
+#' A function to perform element perturbation of a matrix population model for
+#' any demographic statistic.
+#'
+#' A function to perform element perturbation of a matrix population model and
+#' measure the response of the per-capita population growth rate at equilibrium
+#' or (with a user-supplied function) any other demographic statistic.
+#'
+#' @param matU The U matrix (processes related to survival, growth and
+#'   retrogression).
 #' @param matF The F matrix (sexual reproduction processes).
 #' @param matC The C matrix (clonal reproduction processes).
 #' @param pert Perturbation parameter.
+#' @param demogstat A character string that is the name of a function. The
+#'   default is the per-capita population growth rate at equilibrium. Also
+#'   accepts a user-supplied function that performs a calculation on a
+#'   projection matrix and returns a single numeric value.
 #' @param ... Additional arguments passed to the function \code{demogstat}.
-#' @return %% ~Describe the value returned 
+#' @return %% ~Describe the value returned
 #' @note %% ~~further notes~~
 #' @author Roberto Salguero-Gomez <r.salguero@@sheffield.ac.uk>
 #' @references %% ~~references~~

--- a/R/matrixElementPerturbation.R
+++ b/R/matrixElementPerturbation.R
@@ -1,6 +1,6 @@
 #' A function to perform element perturbation of a matrix population model for any demographic statistic.
 #' 
-#' A function to perform element perturbation of a matrix population model and measure the response of the per-capita population growth rate at equilibrium (λ) or (with a user-supplied function) any other demographic statistic.
+#' A function to perform element perturbation of a matrix population model and measure the response of the per-capita population growth rate at equilibrium or (with a user-supplied function) any other demographic statistic.
 #' 
 #' @param matU The U matrix (processes related to survival, growth and retrogression).
 #' @param matF The F matrix (sexual reproduction processes).

--- a/R/standardizedvitalrates.R
+++ b/R/standardizedvitalrates.R
@@ -31,7 +31,10 @@ standardizedVitalRates <- function(matU, matF, reproStages, matrixStages) {
                            rearr$matrixStages)
   
   # collapse
-  xx <- Rcompadre::collapseMatrix(matU, matF, collapse = collapse)
+  #First make a 0 matrix for matC because collapseMatrix expects a matrix.
+  matC <- matrix(0, nrow = nrow(matU), ncol = ncol(matU))
+  
+  xx <- Rcompadre::collapseMatrix(matU, matF, matC, collapse = collapse)
   matUcollapse <- xx$matU
   matUcollapse[is.na(collapse), is.na(collapse)] <- NA
   

--- a/R/vitalRatePerturbation.R
+++ b/R/vitalRatePerturbation.R
@@ -1,13 +1,21 @@
-#' A function to perform perturbation of vital rates of the matrix model for any demographic statistic.
-#' 
-#' A function to perform perturbation of vital rates of the matrix model and measure the response of the per-capita population growth rate at equilibrium or (with a user-supplied function) any other demographic statistic.
-#' 
+#' A function to perform perturbation of vital rates of the matrix model for any
+#' demographic statistic.
+#'
+#' A function to perform perturbation of vital rates of the matrix model and
+#' measure the response of the per-capita population growth rate at equilibrium
+#' or (with a user-supplied function) any other demographic statistic.
+#'
 #' %% ~~ If necessary, more details than the description above ~~
-#' 
-#' @param matU The U matrix (processes related to survival, growth and retrogression).
+#'
+#' @param matU The U matrix (processes related to survival, growth and
+#'   retrogression).
 #' @param matF The F matrix (sexual reproduction processes).
 #' @param matC The C matrix (clonal reproduction processes).
-#' @param demogstat The demographic statistic to be used, as in "the sensitvity/elasticity of ___ to vital rate perturbations." Defaults to the per-capita population growth rate at equilibrium. Also accepts a user-supplied function that performs a calculation on a projection matrix and returns a single numeric value.
+#' @param demogstat The demographic statistic to be used, as in "the
+#'   sensitvity/elasticity of ___ to vital rate perturbations." Defaults to the
+#'   per-capita population growth rate at equilibrium. Also accepts a
+#'   user-supplied function that performs a calculation on a projection matrix
+#'   and returns a single numeric value.
 #' @param pert Magnitude of the perturbation (defaults to 0.001).
 #' @return A data frame containing...
 #' @note %% ~~further notes~~

--- a/R/vitalRatePerturbation.R
+++ b/R/vitalRatePerturbation.R
@@ -1,13 +1,13 @@
 #' A function to perform perturbation of vital rates of the matrix model for any demographic statistic.
 #' 
-#' A function to perform perturbation of vital rates of the matrix model and measure the response of the per-capita population growth rate at equilibrium (λ) or (with a user-supplied function) any other demographic statistic.
+#' A function to perform perturbation of vital rates of the matrix model and measure the response of the per-capita population growth rate at equilibrium or (with a user-supplied function) any other demographic statistic.
 #' 
 #' %% ~~ If necessary, more details than the description above ~~
 #' 
 #' @param matU The U matrix (processes related to survival, growth and retrogression).
 #' @param matF The F matrix (sexual reproduction processes).
 #' @param matC The C matrix (clonal reproduction processes).
-#' @param demogstat The demographic statistic to be used, as in "the sensitvity/elasticity of ___ to vital rate perturbations." Defaults to the per-capita population growth rate at equilibrium (λ). Also accepts a user-supplied function that performs a calculation on a projection matrix and returns a single numeric value.
+#' @param demogstat The demographic statistic to be used, as in "the sensitvity/elasticity of ___ to vital rate perturbations." Defaults to the per-capita population growth rate at equilibrium. Also accepts a user-supplied function that performs a calculation on a projection matrix and returns a single numeric value.
 #' @param pert Magnitude of the perturbation (defaults to 0.001).
 #' @return A data frame containing...
 #' @note %% ~~further notes~~
@@ -17,7 +17,7 @@
 #' @keywords ~kwd1 ~kwd2
 #' @examples
 #' 
-#' ## Not run:
+#' \dontrun{
 #' data(Compadre)
 #' pira <- subsetDB(Compadre, SpeciesAccepted == "Pinus radiata")
 #' 
@@ -37,8 +37,7 @@
 #' }
 #' vitalRatePerturbation(matU = pira@matU, matF = pira@matF, stat = damping)
 #' vitalRatePerturbation(matU = pira@matU, matF = pira@matF, stat = "damping")
-#' 
-#' ## End(Not run)
+#' }
 #' 
 #' 
 #' @importFrom popbio eigen.analysis

--- a/R/vitalRates.R
+++ b/R/vitalRates.R
@@ -55,9 +55,9 @@
 #' @keywords ~kwd1 ~kwd2
 #' @examples
 #' 
-#' matU <- matrix (c(0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.3, 0, 0, 0, 0, 0.1, 0.1), nrow = 4, byrow = T)
-#' matF <- matrix (c(0, 0, 5, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), nrow = 4, byrow = T)
-#' matC <- matrix (c(0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0), nrow = 4, byrow = T)
+#' matU <- matrix (c(0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.3, 0, 0, 0, 0, 0.1, 0.1), nrow = 4, byrow = TRUE)
+#' matF <- matrix (c(0, 0, 5, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), nrow = 4, byrow = TRUE)
+#' matC <- matrix (c(0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0), nrow = 4, byrow = TRUE)
 #' 
 #' #Vital rate outputs without weights:
 #' vitalRates(matU, matF, matC, splitStages = 'all', weighted = FALSE)
@@ -72,11 +72,6 @@
 #' vitalRates(matU, matF, matC, splitStages = c('prop', 'active', 'active', 'active'), weighted = 'SSD')
 #' 
 #' #Vital rate outputs weighted by a chosen population vector of initial conditions:
-#' initialConditions <- c(100, 10, 0, 1)
-#' 
-#' vitalRates(matU, matF, matC, splitStages = 'all', weighted = initialConditions)
-#' vitalRates(matU, matF, matC, splitStages = 'ontogeny', weighted = initialConditions)
-#' vitalRates(matU, matF, matC, splitStages = c('prop', 'active', 'active', 'active'), weighted = initialConditions)
 #' 
 #' @export
 vitalRates <- function(matU, matF, matC = NULL, splitStages = FALSE, weighted = FALSE){
@@ -144,16 +139,16 @@ vitalRates <- function(matU, matF, matC = NULL, splitStages = FALSE, weighted = 
     adu <- which(colSums(matF)>0)  #This classification does not accoutn for non- and post-reproductive
     juv <- which(colSums(matF)==0)
     
-    out$survJuv <- mean(surv1[juv], na.rm=T)
-    out$retrJuv <- mean(retr1[juv], na.rm=T)
-    out$progJuv <- mean(prog1[juv], na.rm=T)
-    out$cloJuv  <- mean(clo1[juv], na.rm=T)
+    out$survJuv <- mean(surv1[juv], na.rm=TRUE)
+    out$retrJuv <- mean(retr1[juv], na.rm=TRUE)
+    out$progJuv <- mean(prog1[juv], na.rm=TRUE)
+    out$cloJuv  <- mean(clo1[juv], na.rm=TRUE)
     
-    out$survAdu <- mean(surv1[adu], na.rm=T)
-    out$retrAdu <- mean(retr1[adu], na.rm=T)
-    out$progAdu <- mean(prog1[adu], na.rm=T)
-    out$fecAdu  <- mean(fec1[adu], na.rm=T)
-    out$cloAdu  <- mean(clo1[adu], na.rm=T)
+    out$survAdu <- mean(surv1[adu], na.rm=TRUE)
+    out$retrAdu <- mean(retr1[adu], na.rm=TRUE)
+    out$progAdu <- mean(prog1[adu], na.rm=TRUE)
+    out$fecAdu  <- mean(fec1[adu], na.rm=TRUE)
+    out$cloAdu  <- mean(clo1[adu], na.rm=TRUE)
     }
   
   if (splitStages[1] %in% c('prop','active','dorm')){
@@ -161,18 +156,18 @@ vitalRates <- function(matU, matF, matC = NULL, splitStages = FALSE, weighted = 
     active <- which(splitStages=="active")
     dorm <- which(splitStages=="dorm")
     
-    out$survProp <- mean(surv1[prop], na.rm=T)
-    out$progProp <- mean(prog1[prop], na.rm=T)
+    out$survProp <- mean(surv1[prop], na.rm=TRUE)
+    out$progProp <- mean(prog1[prop], na.rm=TRUE)
     
-    out$survActive <- mean(surv1[active], na.rm=T)
-    out$retrActive <- mean(retr1[active], na.rm=T)
-    out$progActive <- mean(prog1[active], na.rm=T)
-    out$fecActive  <- mean(fec1[active], na.rm=T)
-    out$cloActive  <- mean(clo1[active], na.rm=T)
+    out$survActive <- mean(surv1[active], na.rm=TRUE)
+    out$retrActive <- mean(retr1[active], na.rm=TRUE)
+    out$progActive <- mean(prog1[active], na.rm=TRUE)
+    out$fecActive  <- mean(fec1[active], na.rm=TRUE)
+    out$cloActive  <- mean(clo1[active], na.rm=TRUE)
     
-    out$survDorm <- mean(surv1[dorm], na.rm=T)
-    out$retrDorm <- mean(retr1[dorm], na.rm=T)
-    out$progDorm <- mean(prog1[dorm], na.rm=T)
+    out$survDorm <- mean(surv1[dorm], na.rm=TRUE)
+    out$retrDorm <- mean(retr1[dorm], na.rm=TRUE)
+    out$progDorm <- mean(prog1[dorm], na.rm=TRUE)
   }
   
 	return(out)

--- a/man/longevity.Rd
+++ b/man/longevity.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/longevity.R
 \name{longevity}
 \alias{longevity}
-\title{A function to calculate measures of longevity.}
+\title{Calculate measures of life expectancy and longevity}
 \usage{
 longevity(matU, startLife = 1, initPop = 100, run = 1000)
 }
@@ -15,21 +15,22 @@ of life.}
 
 \item{initPop}{Initial population size.}
 
-\item{run}{Number of iterations that the maximum longevity will be
-calculated for.}
+\item{run}{Number of iterations that maximum longevity will be calculated
+over.}
 }
 \value{
-This function applies Markov chain approaches to obtain mean life
-expectancy, and a loop to calculate maximum longevity. Outputs are:
+Returns a list including the following named elements (each of which
+  contain a single numeric value):
 
-- 'eta': mean life expectancy conditional on entering the life cycle on life
-stage described by 'startLife'.
+  - \code{eta}: mean life expectancy conditional on entering the life cycle
+  at life stage described by \code{startLife}
 
-- 'var_eta': variance in life expectancy conditional on entering the life
-cycle on life stage described by 'startLife'.
+  - \code{var_eta}: variance in life expectancy conditional on entering the
+  life cycle at life stage described by \code{startLife}
 
-- 'Max': maximum longevity observed by iterating a population vector with
-'initPop' individuals in stage 'startLife' up to 'run' times.
+  - \code{Max}: maximum longevity observed by iterating a population vector
+  with \code{initPop} individuals in stage \code{startLife} up to \code{run}
+  times
 }
 \description{
 A function to calculate life expectancy and maximum longevity of individuals
@@ -43,20 +44,20 @@ in life expectancy, and a loop to calculate maximum longevity.
 %% ~~further notes~~
 }
 \examples{
-
-matU <- matrix (c(0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.3, 0, 0, 0, 0, 0.1, 0.1), nrow = 4, byrow = TRUE)
+matU <- matrix(c(0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.3, 0, 0, 0, 0, 0.1, 0.1),
+               nrow = 4, byrow = TRUE)
 
 longevity(matU, startLife = 1, initPop = 100, run = 1000)
 
 }
 \references{
 Caswell, H. (2001) Matrix Population Models: Construction,
-Analysis, and Interpretation. Sinauer Associates; 2nd edition. ISBN:
-978-0878930968
+  Analysis, and Interpretation. Sinauer Associates; 2nd edition. ISBN:
+  978-0878930968
 
-Morris, W. F., and D. F. Doak. 2003. Quantitative Conservation 
-Biology: Theory and Practice of Population Viability Analysis. 
-Sinauer Associates, Sunderland, Massachusetts, USA
+  Morris, W. F., and D. F. Doak. 2003. Quantitative Conservation Biology:
+  Theory and Practice of Population Viability Analysis. Sinauer Associates,
+  Sunderland, Massachusetts, USA
 }
 \author{
 Roberto Salguero-Gomez <rob.salguero@zoo.ox.ac.uk>

--- a/man/longevity.Rd
+++ b/man/longevity.Rd
@@ -14,7 +14,7 @@ stasis, shrinkage).}
 \item{startLife}{Index of the first stage at which the author considers the
 beginning of life.}
 
-\item{initPop}{Initial population size.}
+\item{initPop}{Initial population size used to calculate maximum longevity.}
 
 \item{run}{Number of iterations that maximum longevity will be calculated
 over.}
@@ -55,10 +55,14 @@ in life expectancy, and/or a loop to calculate maximum longevity.
 %% ~~further notes~~
 }
 \examples{
-matU <- matrix(c(0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.3, 0, 0, 0, 0, 0.1, 0.1),
-               nrow = 4, byrow = TRUE)
+matU <- rbind(c(0.0, 0.0, 0.0, 0.0),
+              c(0.5, 0.0, 0.0, 0.0),
+              c(0.0, 0.3, 0.0, 0.0),
+              c(0.0, 0.0, 0.1, 0.1))
 
-longevity(matU, startLife = 1, initPop = 100, run = 1000)
+longevity(matU)
+longevity(matU, startLife = 2, method = 'life')
+longevity(matU, startLife = 2, run = 100, method = 'longevity')
 
 }
 \references{

--- a/man/longevity.Rd
+++ b/man/longevity.Rd
@@ -4,33 +4,44 @@
 \alias{longevity}
 \title{Calculate measures of life expectancy and longevity}
 \usage{
-longevity(matU, startLife = 1, initPop = 100, run = 1000)
+longevity(matU, startLife = 1, initPop = 100, run = 1000,
+  method = "both")
 }
 \arguments{
 \item{matU}{A matrix containing only survival-dependent processes (growth,
 stasis, shrinkage).}
 
-\item{startLife}{The first stage at which the author consider the beginning
-of life.}
+\item{startLife}{Index of the first stage at which the author considers the
+beginning of life.}
 
 \item{initPop}{Initial population size.}
 
 \item{run}{Number of iterations that maximum longevity will be calculated
 over.}
+
+\item{method}{Should function return life expectancy (\code{"life"}), maximum
+longevity (\code{"longevity"}), or both (\code{"both"})?}
 }
 \value{
 Returns a list including the following named elements (each of which
   contain a single numeric value):
+  
+  If \code{method == "life"}:
 
   - \code{eta}: mean life expectancy conditional on entering the life cycle
   at life stage described by \code{startLife}
 
   - \code{var_eta}: variance in life expectancy conditional on entering the
   life cycle at life stage described by \code{startLife}
+  
+  If \code{method == "longevity"}:
 
   - \code{Max}: maximum longevity observed by iterating a population vector
   with \code{initPop} individuals in stage \code{startLife} up to \code{run}
   times
+  
+  If \code{method == "both"}, returns a list containing all three elements
+  described above.
 }
 \description{
 A function to calculate life expectancy and maximum longevity of individuals
@@ -38,7 +49,7 @@ in a matrix population model
 }
 \details{
 This function applies Markov chain approaches to obtain the mean and variance
-in life expectancy, and a loop to calculate maximum longevity.
+in life expectancy, and/or a loop to calculate maximum longevity.
 }
 \note{
 %% ~~further notes~~

--- a/man/matrixElementPerturbation.Rd
+++ b/man/matrixElementPerturbation.Rd
@@ -22,7 +22,7 @@ matrixElementPerturbation(matU, matF, matC = NULL, demogstat = "lambda",
 %% ~Describe the value returned
 }
 \description{
-A function to perform element perturbation of a matrix population model and measure the response of the per-capita population growth rate at equilibrium (λ) or (with a user-supplied function) any other demographic statistic.
+A function to perform element perturbation of a matrix population model and measure the response of the per-capita population growth rate at equilibrium or (with a user-supplied function) any other demographic statistic.
 }
 \note{
 %% ~~further notes~~

--- a/man/matrixElementPerturbation.Rd
+++ b/man/matrixElementPerturbation.Rd
@@ -2,17 +2,24 @@
 % Please edit documentation in R/matrixElementPerturbation.R
 \name{matrixElementPerturbation}
 \alias{matrixElementPerturbation}
-\title{A function to perform element perturbation of a matrix population model for any demographic statistic.}
+\title{A function to perform element perturbation of a matrix population model for
+any demographic statistic.}
 \usage{
 matrixElementPerturbation(matU, matF, matC = NULL, demogstat = "lambda",
   pert = 0.001, ...)
 }
 \arguments{
-\item{matU}{The U matrix (processes related to survival, growth and retrogression).}
+\item{matU}{The U matrix (processes related to survival, growth and
+retrogression).}
 
 \item{matF}{The F matrix (sexual reproduction processes).}
 
 \item{matC}{The C matrix (clonal reproduction processes).}
+
+\item{demogstat}{A character string that is the name of a function. The
+default is the per-capita population growth rate at equilibrium. Also
+accepts a user-supplied function that performs a calculation on a
+projection matrix and returns a single numeric value.}
 
 \item{pert}{Perturbation parameter.}
 
@@ -22,7 +29,9 @@ matrixElementPerturbation(matU, matF, matC = NULL, demogstat = "lambda",
 %% ~Describe the value returned
 }
 \description{
-A function to perform element perturbation of a matrix population model and measure the response of the per-capita population growth rate at equilibrium or (with a user-supplied function) any other demographic statistic.
+A function to perform element perturbation of a matrix population model and
+measure the response of the per-capita population growth rate at equilibrium
+or (with a user-supplied function) any other demographic statistic.
 }
 \note{
 %% ~~further notes~~

--- a/man/vitalRatePerturbation.Rd
+++ b/man/vitalRatePerturbation.Rd
@@ -14,7 +14,7 @@ vitalRatePerturbation(matU, matF, matC = NULL, demogstat = "lambda",
 
 \item{matC}{The C matrix (clonal reproduction processes).}
 
-\item{demogstat}{The demographic statistic to be used, as in "the sensitvity/elasticity of ___ to vital rate perturbations." Defaults to the per-capita population growth rate at equilibrium (λ). Also accepts a user-supplied function that performs a calculation on a projection matrix and returns a single numeric value.}
+\item{demogstat}{The demographic statistic to be used, as in "the sensitvity/elasticity of ___ to vital rate perturbations." Defaults to the per-capita population growth rate at equilibrium. Also accepts a user-supplied function that performs a calculation on a projection matrix and returns a single numeric value.}
 
 \item{pert}{Magnitude of the perturbation (defaults to 0.001).}
 }
@@ -22,7 +22,7 @@ vitalRatePerturbation(matU, matF, matC = NULL, demogstat = "lambda",
 A data frame containing...
 }
 \description{
-A function to perform perturbation of vital rates of the matrix model and measure the response of the per-capita population growth rate at equilibrium (λ) or (with a user-supplied function) any other demographic statistic.
+A function to perform perturbation of vital rates of the matrix model and measure the response of the per-capita population growth rate at equilibrium or (with a user-supplied function) any other demographic statistic.
 }
 \details{
 %% ~~ If necessary, more details than the description above ~~
@@ -32,7 +32,7 @@ A function to perform perturbation of vital rates of the matrix model and measur
 }
 \examples{
 
-## Not run:
+\dontrun{
 data(Compadre)
 pira <- subsetDB(Compadre, SpeciesAccepted == "Pinus radiata")
 
@@ -52,8 +52,7 @@ return(dm[1] / dm[2])
 }
 vitalRatePerturbation(matU = pira@matU, matF = pira@matF, stat = damping)
 vitalRatePerturbation(matU = pira@matU, matF = pira@matF, stat = "damping")
-
-## End(Not run)
+}
 
 
 }

--- a/man/vitalRatePerturbation.Rd
+++ b/man/vitalRatePerturbation.Rd
@@ -2,19 +2,25 @@
 % Please edit documentation in R/vitalRatePerturbation.R
 \name{vitalRatePerturbation}
 \alias{vitalRatePerturbation}
-\title{A function to perform perturbation of vital rates of the matrix model for any demographic statistic.}
+\title{A function to perform perturbation of vital rates of the matrix model for any
+demographic statistic.}
 \usage{
 vitalRatePerturbation(matU, matF, matC = NULL, demogstat = "lambda",
   pert = 0.001)
 }
 \arguments{
-\item{matU}{The U matrix (processes related to survival, growth and retrogression).}
+\item{matU}{The U matrix (processes related to survival, growth and
+retrogression).}
 
 \item{matF}{The F matrix (sexual reproduction processes).}
 
 \item{matC}{The C matrix (clonal reproduction processes).}
 
-\item{demogstat}{The demographic statistic to be used, as in "the sensitvity/elasticity of ___ to vital rate perturbations." Defaults to the per-capita population growth rate at equilibrium. Also accepts a user-supplied function that performs a calculation on a projection matrix and returns a single numeric value.}
+\item{demogstat}{The demographic statistic to be used, as in "the
+sensitvity/elasticity of ___ to vital rate perturbations." Defaults to the
+per-capita population growth rate at equilibrium. Also accepts a
+user-supplied function that performs a calculation on a projection matrix
+and returns a single numeric value.}
 
 \item{pert}{Magnitude of the perturbation (defaults to 0.001).}
 }
@@ -22,7 +28,9 @@ vitalRatePerturbation(matU, matF, matC = NULL, demogstat = "lambda",
 A data frame containing...
 }
 \description{
-A function to perform perturbation of vital rates of the matrix model and measure the response of the per-capita population growth rate at equilibrium or (with a user-supplied function) any other demographic statistic.
+A function to perform perturbation of vital rates of the matrix model and
+measure the response of the per-capita population growth rate at equilibrium
+or (with a user-supplied function) any other demographic statistic.
 }
 \details{
 %% ~~ If necessary, more details than the description above ~~

--- a/man/vitalRates.Rd
+++ b/man/vitalRates.Rd
@@ -67,9 +67,9 @@ cycle represented in the matrix population model.
 }
 \examples{
 
-matU <- matrix (c(0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.3, 0, 0, 0, 0, 0.1, 0.1), nrow = 4, byrow = T)
-matF <- matrix (c(0, 0, 5, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), nrow = 4, byrow = T)
-matC <- matrix (c(0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0), nrow = 4, byrow = T)
+matU <- matrix (c(0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.3, 0, 0, 0, 0, 0.1, 0.1), nrow = 4, byrow = TRUE)
+matF <- matrix (c(0, 0, 5, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), nrow = 4, byrow = TRUE)
+matC <- matrix (c(0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0), nrow = 4, byrow = TRUE)
 
 #Vital rate outputs without weights:
 vitalRates(matU, matF, matC, splitStages = 'all', weighted = FALSE)
@@ -84,11 +84,6 @@ vitalRates(matU, matF, matC, splitStages = 'ontogeny', weighted = 'SSD')
 vitalRates(matU, matF, matC, splitStages = c('prop', 'active', 'active', 'active'), weighted = 'SSD')
 
 #Vital rate outputs weighted by a chosen population vector of initial conditions:
-initialConditions <- c(100, 10, 0, 1)
-
-vitalRates(matU, matF, matC, splitStages = 'all', weighted = initialConditions)
-vitalRates(matU, matF, matC, splitStages = 'ontogeny', weighted = initialConditions)
-vitalRates(matU, matF, matC, splitStages = c('prop', 'active', 'active', 'active'), weighted = initialConditions)
 
 }
 \references{


### PR DESCRIPTION
Add `method` argument to `longevity` function to allow user to select which components to return (life expectancy, maximum longevity, or both), based on #13 .

Also includes edits to remove outstanding build errors in Dev branch (these are 'quick fixes' copied from recent edits to Master.)

Also fixes error in max longevity loop (variable `runs` had been inadvertently fixed at 1000), and includes edits to formatting and language of `longevity` documentation.